### PR TITLE
Create ForbiddenHttpException.php

### DIFF
--- a/src/ForbiddenHttpException.php
+++ b/src/ForbiddenHttpException.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Fuzz\HttpException;
+
+/**
+ * Empty class providing the formal status phrase for 403
+ */
+class ForbiddenHttpException extends AccessDeniedHttpException
+{
+	/**
+	 * Error code storage;
+	 *
+	 * @const string
+	 */
+	const ERROR = 'forbidden';
+}


### PR DESCRIPTION
Add Exception class with formal "Forbidden" name for 403

---

If the original project owner is still around, i added a patch-level change to offer "Forbidden" as a 403 implementation.

Use case for me is complicated - basically I have to use the code integer and match the phrase associated with it to an Exception class. My legacy code isn't PSR-7 ready, and yours is the most basic set of classes i could find that doesn't require it.